### PR TITLE
feature: Refactor WindowManager to support lyric widget management

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -14,10 +14,10 @@ target_link_libraries(TrayMusicPlayer PRIVATE
 )
 
 
-if(WIN32)
-    set_target_properties(TrayMusicPlayer PROPERTIES
-            WIN32_EXECUTABLE TRUE
-    )
-endif()
+# if(WIN32)
+#     set_target_properties(TrayMusicPlayer PROPERTIES
+#             WIN32_EXECUTABLE TRUE
+#     )
+# endif()
 
 qt_finalize_target(TrayMusicPlayer)

--- a/app/trayapp.cpp
+++ b/app/trayapp.cpp
@@ -1,7 +1,6 @@
 //
 // Created by cww on 25-2-13.
 //
-
 #include "trayapp.h"
 #include "windowmanager.h"
 #include <core.h>
@@ -12,97 +11,105 @@
 #include <QMessageBox>
 #include <QSystemTrayIcon>
 
-inline void Init_qrc() {
+inline void Init_qrc()
+{
     Q_INIT_RESOURCE(svg);
     Q_INIT_RESOURCE(qss);
 }
 
-namespace Tray {
-    class TrayAppPrivate {
-    public:
-        explicit TrayAppPrivate(TrayApp *w);
+namespace Tray
+{
+class TrayAppPrivate
+{
+public:
+    explicit TrayAppPrivate(TrayApp* w);
 
-        static constexpr int MAIN_MINIMUM_WIDTH = 600;
-        static constexpr int MAIN_MINIMUM_HEIGHT = 450;
-        QAction *m_minimizeAction;
-        QAction *m_maximizeAction;
-        QAction *m_restoreAction;
-        QAction *m_quitAction;
-        QSystemTrayIcon *m_systemTrayIcon;
-        QMenu *m_trayIconMenu;
-        Ui::WindowManager *m_windowManager;
-        Core::Core *m_core;
-        QPixmap *m_pixmapBackGround;
-        TrayApp *q_ptr;
-    };
+    static constexpr int MAIN_MINIMUM_WIDTH = 600;
+    static constexpr int MAIN_MINIMUM_HEIGHT = 450;
+    QAction* m_minimizeAction;
+    QAction* m_maximizeAction;
+    QAction* m_restoreAction;
+    QAction* m_quitAction;
+    QSystemTrayIcon* m_systemTrayIcon;
+    QMenu* m_trayIconMenu;
+    Ui::WindowManager* m_windowManager;
+    Core::Core* m_core;
+    QPixmap* m_pixmapBackGround;
+    TrayApp* q_ptr;
+};
 
-    TrayAppPrivate::TrayAppPrivate(TrayApp *w): q_ptr(w) {
-        m_trayIconMenu = new QMenu(q_ptr);
-        m_systemTrayIcon = new QSystemTrayIcon(q_ptr);
-        m_minimizeAction = new QAction(QCoreApplication::translate("TrayUI", "Minimize"), q_ptr);
-        m_maximizeAction = new QAction(QCoreApplication::translate("TrayUI", "Maximize"), q_ptr);
-        m_restoreAction = new QAction(QCoreApplication::translate("TrayUI", "Restore"), q_ptr);
-        m_quitAction = new QAction(QCoreApplication::translate("TrayUI", "Quit"), q_ptr);
-        m_trayIconMenu->addAction(m_minimizeAction);
-        m_trayIconMenu->addAction(m_maximizeAction);
-        m_trayIconMenu->addAction(m_restoreAction);
-        m_trayIconMenu->addSeparator();
-        m_trayIconMenu->addAction(m_quitAction);
-        m_systemTrayIcon->setContextMenu(m_trayIconMenu);
-        const auto icon = QIcon(Res::TrayIconSVG);
-        m_systemTrayIcon->setIcon(icon);
-        q_ptr->setWindowIcon(icon);
-        m_systemTrayIcon->setToolTip("Tray Music");
-        m_systemTrayIcon->show();
+TrayAppPrivate::TrayAppPrivate(TrayApp* w): q_ptr(w)
+{
+    m_trayIconMenu = new QMenu(q_ptr);
+    m_systemTrayIcon = new QSystemTrayIcon(q_ptr);
+    m_minimizeAction = new QAction(QCoreApplication::translate("TrayUI", "Minimize"), q_ptr);
+    m_maximizeAction = new QAction(QCoreApplication::translate("TrayUI", "Maximize"), q_ptr);
+    m_restoreAction = new QAction(QCoreApplication::translate("TrayUI", "Restore"), q_ptr);
+    m_quitAction = new QAction(QCoreApplication::translate("TrayUI", "Quit"), q_ptr);
+    m_trayIconMenu->addAction(m_minimizeAction);
+    m_trayIconMenu->addAction(m_maximizeAction);
+    m_trayIconMenu->addAction(m_restoreAction);
+    m_trayIconMenu->addSeparator();
+    m_trayIconMenu->addAction(m_quitAction);
+    m_systemTrayIcon->setContextMenu(m_trayIconMenu);
+    const auto icon = QIcon(Res::TrayIconSVG);
+    m_systemTrayIcon->setIcon(icon);
+    q_ptr->setWindowIcon(icon);
+    m_systemTrayIcon->setToolTip("Tray Music");
+    m_systemTrayIcon->show();
 
-        m_core = new Core::Core(q_ptr);
-        m_windowManager = new Ui::WindowManager(m_core, q_ptr);
-        m_core->initWork();
-        q_ptr->setCentralWidget(m_windowManager);
-        q_ptr->setMinimumWidth(MAIN_MINIMUM_WIDTH);
-        q_ptr->setMinimumHeight(MAIN_MINIMUM_HEIGHT);
+    m_core = new Core::Core(q_ptr);
+    m_windowManager = new Ui::WindowManager(m_core, q_ptr);
+    m_core->initWork();
+    q_ptr->setCentralWidget(m_windowManager);
+    q_ptr->setMinimumWidth(MAIN_MINIMUM_WIDTH);
+    q_ptr->setMinimumHeight(MAIN_MINIMUM_HEIGHT);
 
-        m_pixmapBackGround = new QPixmap();
+    m_pixmapBackGround = new QPixmap();
+}
+
+TrayApp::TrayApp(QWidget* parent)
+    : QMainWindow(parent)
+{
+    Init_qrc();
+    d = std::make_unique<TrayAppPrivate>(this);
+    createConnections();
+}
+
+TrayApp::~TrayApp() = default;
+
+void TrayApp::createConnections()
+{
+    // quit the application
+    connect(d->m_quitAction, &QAction::triggered, qApp, &QApplication::quit);
+
+    // resize the main window
+    connect(d->m_maximizeAction, &QAction::triggered, this, &TrayApp::showMaximized);
+    connect(d->m_minimizeAction, &QAction::triggered, this, &TrayApp::hide);
+    connect(d->m_restoreAction, &QAction::triggered, this, &TrayApp::showNormal);
+}
+
+void TrayApp::closeEvent(QCloseEvent* event)
+{
+    if (!event->spontaneous() || !isVisible())
+        return;
+    if (d->m_systemTrayIcon->isVisible())
+    {
+        QMessageBox::information(this, tr("Exit the application"),
+                                 tr("The program will keep running in the "
+                                     "system tray. To terminate the program, "
+                                     "choose <b>Quit</b> in the context menu "
+                                     "of the system tray entry."));
+        this->hide();
+        event->ignore();
     }
+}
 
-    TrayApp::TrayApp(QWidget *parent)
-        : QMainWindow(parent) {
-        Init_qrc();
-        d = std::make_unique<TrayAppPrivate>(this);
-        createConnections();
-    }
-
-    TrayApp::~TrayApp() = default;
-
-    void TrayApp::createConnections() {
-        // quit the application
-        connect(d->m_quitAction, &QAction::triggered, qApp, &QApplication::quit);
-
-        // resize the main window
-        connect(d->m_maximizeAction, &QAction::triggered, this, &TrayApp::showMaximized);
-        connect(d->m_minimizeAction, &QAction::triggered, this, &TrayApp::hide);
-        connect(d->m_restoreAction, &QAction::triggered, this, &TrayApp::showNormal);
-    }
-
-    void TrayApp::closeEvent(QCloseEvent *event) {
-        if (!event->spontaneous() || !isVisible())
-            return;
-        if (d->m_systemTrayIcon->isVisible()) {
-            QMessageBox::information(this, tr("Exit the application"),
-                                     tr("The program will keep running in the "
-                                         "system tray. To terminate the program, "
-                                         "choose <b>Quit</b> in the context menu "
-                                         "of the system tray entry."));
-            this->hide();
-            event->ignore();
-        }
-    }
-
-    void TrayApp::setVisible(const bool visible) {
-        d->m_restoreAction->setEnabled(isMaximized() || !visible);
-        d->m_minimizeAction->setEnabled(visible);
-        d->m_maximizeAction->setEnabled(!isMaximized());
-        QMainWindow::setVisible(visible);
-    }
-
+void TrayApp::setVisible(const bool visible)
+{
+    d->m_restoreAction->setEnabled(isMaximized() || !visible);
+    d->m_minimizeAction->setEnabled(visible);
+    d->m_maximizeAction->setEnabled(!isMaximized());
+    QMainWindow::setVisible(visible);
+}
 }

--- a/app/windowmanager.h
+++ b/app/windowmanager.h
@@ -5,83 +5,86 @@
 #include <QWidget>
 #include <memory>
 
-namespace Tray::Core {
-    class Core;
+namespace Tray::Core
+{
+class Core;
 }
-namespace Tray::Ui {
 
-    class WindowManagerPrivate;
+namespace Tray::Ui
+{
+class WindowManagerPrivate;
 
-    class WindowManager final : public QWidget {
-        Q_OBJECT
+class WindowManager final : public QWidget
+{
+    Q_OBJECT
 
-    public:
-        explicit WindowManager(Core::Core *core, QWidget *parent = nullptr);
+public:
+    explicit WindowManager(Core::Core* core, QWidget* parent = nullptr);
 
-        ~WindowManager() override;
+    ~WindowManager() override;
 
-        void initDefaultSettings(const QStringList &localDir, const QStringList &userKeys, unsigned volume);
+    void initDefaultSettings(const QStringList& localDir, const QStringList& userKeys, unsigned volume);
 
-    Q_SIGNALS:
-        void signalPlayToggle();
+Q_SIGNALS:
+    void signalPlayToggle();
 
-        void signalNextMusic();
+    void signalNextMusic();
 
-        void signalPreMusic();
+    void signalPreMusic();
 
-        void signalSetVolume(int);
+    void signalSetVolume(int);
 
-        void signalSetPlayerPosition(qint64);
+    void signalSetPlayerPosition(qint64);
 
-        void signalPlayModeChanged();
+    void signalPlayModeChanged();
 
-        void signalPlaylistButtonClicked(const QString &);
+    void signalPlaylistButtonClicked(const QString&);
 
-        void signalViewPlayButtonClicked(const QString &, int);
+    void signalViewPlayButtonClicked(const QString&, int);
 
-        void signalUserPlaylistButtonAdded(const QString &);
+    void signalUserPlaylistButtonAdded(const QString&);
 
-        void signalLocalMusicDirectoryAdded(const QString &);
+    void signalLocalMusicDirectoryAdded(const QString&);
 
-        void signalLocalMusicDirectoryRemoved(const QString &);
+    void signalLocalMusicDirectoryRemoved(const QString&);
 
-        void signalMusicAddedToList(const QString &, const QString &, int);
+    void signalMusicAddedToList(const QString&, const QString&, int);
 
-        void signalMusicRemovedFromList(const QString &, const QString &);
+    void signalMusicRemovedFromList(const QString&, const QString&);
 
-        void signalUserPlaylistButtonRemoved(const QString &);
+    void signalUserPlaylistButtonRemoved(const QString&);
 
-    public Q_SLOTS:
-        void updateCurrentMusic(int index, const QString &name, int duration);
+public Q_SLOTS:
+    void updateCurrentMusic(int index, const QString& name, int duration);
 
-        void updateProgressBarPosition(qint64 pos);
+    void updateProgressBarPosition(qint64 pos);
 
-        void updateVolumeCtrlButtonIcon(bool b);
+    void updateVolumeCtrlButtonIcon(bool b);
 
-        void updatePlayModeIcon(int mode);
+    void updatePlayModeIcon(int mode);
 
-        void showCurrentTitleListToView(const QString &name, const QStringList &titleList);
+    void showCurrentTitleListToView(const QString& name, const QStringList& titleList);
 
-        void updatePlayingStatus(bool b);
+    void updatePlayingStatus(bool b);
 
-        void updateUserPlaylistKeys(const QStringList &list);
+    void updateUserPlaylistKeys(const QStringList& list);
 
-        void updateCurrentViewList(const QString &key, const QStringList &titleList);
+    void updateCurrentViewList(const QString& key, const QStringList& titleList);
 
-        /// @brief This function is connected with the signal that will be emitted when current playlist changed
-        /// this function calls the viewWidget's function to update the current playlist key
-        /// @param key playlist key
-        void updateCurrentPlaylistKey(const QString &key);
+    /// @brief This function is connected with the signal that will be emitted when current playlist changed
+    /// this function calls the viewWidget's function to update the current playlist key
+    /// @param key playlist key
+    void updateCurrentPlaylistKey(const QString& key);
 
-        void updateSettingsLocalPaths(const QStringList &paths);
+    void updateSettingsLocalPaths(const QStringList& paths);
 
-        void removeUserPlaylistButton(const QString &key);
+    void removeUserPlaylistButton(const QString& key);
 
-        void addUserPlaylistButton(const QString &key);
+    void addUserPlaylistButton(const QString& key);
 
-    private:
-        std::unique_ptr<WindowManagerPrivate> d;
+private:
+    std::unique_ptr<WindowManagerPrivate> d;
 
-        void createConnections();
-    };
+    void createConnections();
+};
 }

--- a/core/common/trayconfig.h
+++ b/core/common/trayconfig.h
@@ -12,7 +12,7 @@ inline constexpr int UNINITIALIZED_VALUE = -1;
 
 #if defined(Q_OS_WIN32)
 inline const auto PROJECT_PATH =
-    QStringLiteral("C:/Users/cww/Documents/Workspace/TrayMusicPlayer/");
+    QStringLiteral("C:/Users/31305/Documents/Workspace/TrayMusicPlayer/");
 #elif defined(Q_OS_LINUX)
 inline const auto PROJECT_PATH =
     QStringLiteral("/home/aude/workspace/qt/TrayMusicPlayer/");

--- a/resource/include/trayqss.h
+++ b/resource/include/trayqss.h
@@ -16,4 +16,6 @@ namespace Tray::Res{
     inline const auto PLAY_MODE_QSS = QStringLiteral(":/qss/MusicListButton/ButtonPlayMode.qss");
     inline const auto PROGRESS_BAR_QSS = QStringLiteral(":/qss/Slider/ProgressBar.qss");
     inline const auto CONFIG_ACTION_QSS = QStringLiteral(":/qss/MusicListButton/ButtonAction.qss");
+    inline const auto VIEW_SPLITTER_QSS = QStringLiteral(":/qss/Splitter/Splitter.qss");
+    inline const auto HERIZONTAL_LINE_QSS = QStringLiteral(":/qss/QFrame/Line.qss");
 }

--- a/resource/qss.qrc
+++ b/resource/qss.qrc
@@ -11,5 +11,7 @@
    <file>qss/Slider/ProgressBar.qss</file>
    <file>qss/QMenu/VolumeMenu.qss</file>
    <file>qss/MusicListButton/ButtonAction.qss</file>
+   <file>qss/Splitter/Splitter.qss</file>
+   <file>qss/QFrame/Line.qss</file>
 </qresource>
 </RCC>

--- a/resource/qss/QFrame/Line.qss
+++ b/resource/qss/QFrame/Line.qss
@@ -1,0 +1,5 @@
+QFrame {
+    border: none; /* 移除默认边框 */
+    background-color: #999999; /* 设置线条颜色 */
+    max-height: 1px; /* 设置线条粗细 */
+}

--- a/resource/qss/Splitter/Splitter.qss
+++ b/resource/qss/Splitter/Splitter.qss
@@ -1,0 +1,6 @@
+QSplitter::handle {
+    background-color: gray
+}
+QSplitter::handle:vertical {
+    height: 1px;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,11 @@
+message(STATUS "Test Module ON")
+
+## TestConfigWidget
 qt_add_executable(test_config_widget TestConfigWidget.cpp)
-message("test")
 target_link_libraries(test_config_widget PRIVATE tray_music_ui)
+## TestConfigWidget
+
+## TestSplitter
+qt_add_executable(test_splitter_ui TestSplitter.cpp)
+target_link_libraries(test_splitter_ui PRIVATE tray_music_ui)
+## TestSplitter

--- a/test/TestConfigWidget.cpp
+++ b/test/TestConfigWidget.cpp
@@ -1,10 +1,9 @@
 //
 // Created by cww on 25-6-14.
 //
-#include <filepathconfigwidget.h>
 #include <configwidget.h>
 #include <QApplication>
-#include <memory>
+#include <QLabel>
 
 
 using namespace Tray::Ui;
@@ -13,11 +12,11 @@ int main(int argc, char** argv)
     Q_INIT_RESOURCE(qss);
     Q_INIT_RESOURCE(svg);
     QApplication app(argc, argv);
-    const auto configWidget = std::make_unique<ConfigWidget>();
-    auto *w = new FilePathConfigWidget;
-    QWidget *blankWidget = new QWidget;
-    configWidget->addConfigWidget("null", blankWidget);
-    configWidget->addConfigWidget("test", w);
+    const auto configWidget = std::make_unique<Panel::ConfigWidget>();
+    auto label_1 = new QLabel("Label 1");
+    auto label_2 = new QLabel("Label 2");
+    configWidget->addConfigWidget("test 1", label_1);
+    configWidget->addConfigWidget("test 2", label_2);
     configWidget->show();
     return QApplication::exec();
 }

--- a/test/TestSplitter.cpp
+++ b/test/TestSplitter.cpp
@@ -1,0 +1,41 @@
+//
+// Created by 31305 on 25-6-17.
+//
+#include <QApplication>
+#include <QLabel>
+#include <QSplitter>
+#include <QVBoxLayout>
+#include <QWidget>
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    QWidget w;
+    QLabel* label_up = new QLabel("Up");
+    QLabel* label_down = new QLabel("Down");
+    QLabel* label_other = new QLabel("Other");
+    QLabel* label_other1 = new QLabel("Other1");
+    label_down->setFixedHeight(20);
+    QSplitter* splitter = new QSplitter(Qt::Vertical);
+    QVBoxLayout* layout = new QVBoxLayout;
+    splitter->addWidget(label_up);
+    splitter->addWidget(label_down);
+    splitter->addWidget(label_other);
+    splitter->addWidget(label_other1);
+    splitter->setStyleSheet(
+        "QSplitter::handle {"
+        "    background-color: gray;" // Color of the handle
+        "}"
+        "QSplitter::handle:vertical {"
+        "    height: 1px;" // Height of the vertical handle
+        "}"
+        "QSplitter::handle:horizontal {"
+        "    width: 1px;" // Width of the horizontal handle (not relevant here but good to know)
+        "}"
+    );
+    layout->setContentsMargins(0, 10, 0, 10);
+    layout->addWidget(splitter);
+    w.setLayout(layout);
+    w.show();
+    return QApplication::exec();
+}

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -4,7 +4,7 @@ file(GLOB_RECURSE UI_SOURCES CONFIGURE_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h
         ${CMAKE_CURRENT_SOURCE_DIR}/panels/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/panels/*.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/common/uiconfig.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/common/uitools.h
         ${CMAKE_CURRENT_SOURCE_DIR}/common/uimetadata.h
         ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/*.h
@@ -17,7 +17,6 @@ if (TRAY_TEST)
     target_include_directories(tray_music_ui PUBLIC
             ${CMAKE_CURRENT_SOURCE_DIR}/include
             ${CMAKE_CURRENT_SOURCE_DIR}/panels
-            ${CMAKE_CURRENT_SOURCE_DIR}/common
     )
 else ()
     message(STATUS "No Test ready")
@@ -28,7 +27,6 @@ endif ()
 
 
 target_include_directories(tray_music_ui PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/common
         ${CMAKE_CURRENT_SOURCE_DIR}/panels
 )
 

--- a/ui/filepathconfigwidget.cpp
+++ b/ui/filepathconfigwidget.cpp
@@ -1,7 +1,7 @@
 #include "filepathconfigwidget.h"
 #include <trayqss.h>
 #include <traysvg.h>
-#include <uiconfig.h>
+#include <uitools.h>
 
 #include <QCoreApplication>
 #include <QFileDialog>

--- a/ui/include/musiclistwidget.h
+++ b/ui/include/musiclistwidget.h
@@ -53,6 +53,9 @@ namespace Tray::Ui {
         Panel::BetterButton *m_localListButton;
         QHash<QString, Panel::BetterButton *> m_UserButtonHash;
 
+        static inline const auto LOCAL_LIST_KEY = QStringLiteral("Local");
+        static inline const auto EXPAND_BTN_TEXT = QStringLiteral("User's");
+
         void createConnections();
     };
 }

--- a/ui/include/uitools.h
+++ b/ui/include/uitools.h
@@ -6,19 +6,6 @@
 #include <QFile>
 #include <QDebug>
 
-
-namespace Tray::Ui {
-    inline const auto LOCAL_LIST_KEY = QStringLiteral("Local");
-}
-
-
-namespace Tray::Ui {
-    inline const auto PLAY_ALL_KEY = QStringLiteral("Play All");
-    inline const auto EXPAND_BTN_TEXT = QStringLiteral("User's");
-    constexpr int UNINITIALIZED_VALUE = -1;
-}
-
-
 namespace Tray::Ui {
     inline QString readQSS(const QString &qssPath) {
         if (QFile file(qssPath); file.open(QFile::ReadOnly)) {

--- a/ui/musiclistwidget.cpp
+++ b/ui/musiclistwidget.cpp
@@ -2,7 +2,7 @@
 // Created by cww on 25-4-10.
 //
 #include <musiclistwidget.h>
-#include <uiconfig.h>
+#include <uitools.h>
 #include <betterbutton.h>
 #include <traysvg.h>
 #include <trayqss.h>

--- a/ui/panels/betterbutton.cpp
+++ b/ui/panels/betterbutton.cpp
@@ -2,7 +2,7 @@
 // Created by cww on 25-4-1.
 //
 #include "betterbutton.h"
-#include <uiconfig.h>
+#include <uitools.h>
 #include <QEvent>
 
 

--- a/ui/panels/betterbutton.h
+++ b/ui/panels/betterbutton.h
@@ -3,7 +3,7 @@
 //
 
 #pragma once
-#include <../include/uimetadata.h>
+#include <uimetadata.h>
 #include <QPushButton>
 
 

--- a/ui/panels/progressbar.cpp
+++ b/ui/panels/progressbar.cpp
@@ -4,7 +4,7 @@
 #include "progressbar.h"
 #include <qslider.h>
 #include <trayqss.h>
-#include <uiconfig.h>
+#include <uitools.h>
 
 #include <QHBoxLayout>
 #include <QLabel>

--- a/ui/panels/volumecontroller.cpp
+++ b/ui/panels/volumecontroller.cpp
@@ -4,7 +4,7 @@
 #include "volumecontroller.h"
 #include <betterbutton.h>
 #include <qpushbutton.h>
-#include <uiconfig.h>
+#include <uitools.h>
 #include <traysvg.h>
 #include <trayqss.h>
 #include <QSlider>

--- a/ui/playerwidget.cpp
+++ b/ui/playerwidget.cpp
@@ -4,7 +4,7 @@
 #include <playerwidget.h>
 #include <traysvg.h>
 #include <trayqss.h>
-#include <uiconfig.h>
+#include <uitools.h>
 #include <betterbutton.h>
 #include <progressbar.h>
 #include <volumecontroller.h>

--- a/ui/viewdelegate.cpp
+++ b/ui/viewdelegate.cpp
@@ -2,7 +2,7 @@
 // Created by cww on 25-4-10.
 //
 #include "viewdelegate.h"
-#include <uiconfig.h>
+#include <uitools.h>
 #include <traysvg.h>
 #include <QListView>
 #include <QPainter>

--- a/ui/viewdelegate.h
+++ b/ui/viewdelegate.h
@@ -61,6 +61,7 @@ namespace Tray::Ui {
         constexpr static int VIEW_TEXT_LEFT_PADDING = VIEW_PLAY_BUTTON_PADDING + VIEW_BUTTON_SIZE + 5;
         constexpr static int NAME_FONT_SIZE = 12;
         constexpr static int ARTIST_FONT_SIZE = 9;
+        constexpr static int UNINITIALIZED_VALUE = -1;
 
         inline static const auto COLOR_TEXT_NAME = QStringLiteral("#1C1C1E");
         inline static const auto COLOR_TEXT_ARTIST = QStringLiteral("#5E5E5E");

--- a/ui/viewwidget.cpp
+++ b/ui/viewwidget.cpp
@@ -5,7 +5,7 @@
 #include "viewdelegate.h"
 #include <viewwidget.h>
 #include <betterbutton.h>
-#include <uiconfig.h>
+#include <uitools.h>
 #include <traysvg.h>
 #include <trayqss.h>
 #include <QLabel>
@@ -22,6 +22,7 @@ public:
     constexpr static int PLAYALL_BTN_HEIGHT = 30;
     constexpr static int PLAYALL_BTN_WIDTH = 0;
     constexpr static int SIZE_TITLE_FONT = 14;
+    const static inline auto PLAY_ALL_KEY = QStringLiteral("Play All");
 
     QLabel *m_labelName;
     QListView *m_playListView;


### PR DESCRIPTION
### Refactor: WindowManager UI Structure Enhancement

This PR introduces a refactoring of the `WindowManager` class to improve the organization and clarity of its UI layout setup.

#### Key Updates:

* **QLayout Members as Pointers:** `QLayout` instances (e.g., `m_windowManagerLayout`, `m_primaryWidgetLayout`) within `WindowManagerPrivate` are now managed as **member pointers**. Their construction is centralized in the `WindowManagerPrivate` constructor.

* **Separated UI Initialization:** The `WindowManager` constructor now focuses solely on **assembling the UI layout** using the pre-constructed components from `WindowManagerPrivate`. QSS application for various UI elements is also handled here.

* **Enhanced Layout Segmentation:**
    * **QFrame Dividers:** `m_lineSplitterUp` and `m_lineSplitterDown` (configured as horizontal `QFrame`s) are used to create clear visual separations within the layout, styled via QSS.
    * **Styled QSplitter:** `m_viewAndPlaylistsSplitter` now applies QSS for a more visually distinct and user-friendly appearance.

* **QStackedWidget for Content Management:** `m_mainStackedWidget` is set up to facilitate switching between the primary content view (`m_primaryWidget`) and the **upcoming lyric display widget**. This establishes the core mechanism for content toggling.

These changes aim to streamline the UI setup process, making the code more readable and maintainable for future feature additions.